### PR TITLE
skip re-computing gear table when seed is zero

### DIFF
--- a/fastcdc.go
+++ b/fastcdc.go
@@ -106,8 +106,10 @@ func NewChunker(rd io.Reader, opts Options) (*Chunker, error) {
 		return nil, err
 	}
 
-	for i := 0; i < len(table); i++ {
-		table[i] = table[i] ^ opts.Seed
+	if opts.Seed != 0 {
+		for i := 0; i < len(table); i++ {
+			table[i] = table[i] ^ opts.Seed
+		}
 	}
 
 	normalization := opts.Normalization


### PR DESCRIPTION
This allow the chunker to be able to use in parallel when the seed is zero. Migrate the [fastcdc.patch ](https://github.com/buildbuddy-io/buildbuddy/blob/master/buildpatches/fastcdc.patch)in buildbuddy repo here.
