### PR TITLE
Improve newChunk performance

### DIFF
--- a/fastcdc.go
+++ b/fastcdc.go
@@ -201,7 +201,7 @@ func (c *Chunker) fillBuffer() error {
 	// Fill the rest of the buffer
 	m, err := io.ReadFull(c.rd, c.buf[n:])
 	if err == io.EOF || err == io.ErrUnexpectedEOF {
-		c.end = n+m
+		c.end = n + m
 		c.eof = true
 	} else if err != nil {
 		return err
@@ -236,15 +236,17 @@ func (c *Chunker) Next() (Chunk, error) {
 
 func (c *Chunker) nextChunk(data []byte) (int, uint64) {
 	fp := uint64(0)
-	i := c.minSize
+	n := len(data)
 
-	if len(data) <= c.minSize {
-		return len(data), fp
+	if n <= c.minSize {
+		return n, fp
 	}
 
-	n := min(len(data), c.maxSize)
+	i := c.minSize
+	n = min(n, c.maxSize)
+	m := min(n, c.normSize)
 
-	for ; i < min(n, c.normSize); i++ {
+	for ; i < m; i++ {
 		fp = (fp << 1) + table[data[i]]
 		if (fp & c.maskS) == 0 {
 			return i + 1, fp


### PR DESCRIPTION
Based on https://github.com/jotfs/fastcdc-go/pull/3, but still keep min() to make the code more readable.

Before:
```
goos: linux
goarch: amd64
pkg: github.com/jotfs/fastcdc-go
cpu: AMD Ryzen 9 7900X 12-Core Processor            
BenchmarkFastCDC-24        	1000000000	         0.4822 ns/op	2174618445947.71 MB/s
BenchmarkFastCDCSize/1k-24 	41825430	        27.69 ns/op	36978.31 MB/s	         1.000 chunks	       0 B/op	       0 allocs/op
BenchmarkFastCDCSize/4k-24 	27030913	        43.43 ns/op	94321.19 MB/s	         1.000 chunks	       0 B/op	       0 allocs/op
BenchmarkFastCDCSize/16k-24         	 8204872	       163.4 ns/op	100277.25 MB/s	         1.000 chunks	       1 B/op	       0 allocs/op
BenchmarkFastCDCSize/32k-24         	 2775961	       405.7 ns/op	80772.13 MB/s	         1.000 chunks	       3 B/op	       0 allocs/op
BenchmarkFastCDCSize/64k-24         	 1455499	       799.8 ns/op	81938.23 MB/s	         1.000 chunks	       5 B/op	       0 allocs/op
BenchmarkFastCDCSize/128k-24        	  704042	      1567 ns/op	83657.31 MB/s	         1.000 chunks	      11 B/op	       0 allocs/op
BenchmarkFastCDCSize/256k-24        	  315952	      3245 ns/op	80790.53 MB/s	         1.000 chunks	      26 B/op	       0 allocs/op
BenchmarkFastCDCSize/512k-24        	    9165	    125804 ns/op	4167.50 MB/s	         1.000 chunks	     915 B/op	       0 allocs/op
BenchmarkFastCDCSize/1M-24          	    3088	    388593 ns/op	2698.39 MB/s	         1.000 chunks	    2716 B/op	       0 allocs/op
BenchmarkFastCDCSize/4M-24          	     622	   1719564 ns/op	2439.17 MB/s	         4.000 chunks	   13486 B/op	       0 allocs/op
BenchmarkFastCDCSize/16M-24         	     176	   6754175 ns/op	2483.98 MB/s	        15.00 chunks	   47663 B/op	       0 allocs/op
BenchmarkFastCDCSize/32M-24         	      81	  13240891 ns/op	2534.15 MB/s	        29.00 chunks	  103564 B/op	       0 allocs/op
BenchmarkFastCDCSize/64M-24         	      43	  27625951 ns/op	2429.20 MB/s	        52.00 chunks	  195086 B/op	       0 allocs/op
BenchmarkFastCDCSize/128M-24        	      20	  55096356 ns/op	2436.05 MB/s	       112.0 chunks	  419436 B/op	       0 allocs/op
BenchmarkFastCDCSize/512M-24        	       5	 213082923 ns/op	2519.54 MB/s	       460.0 chunks	 1677744 B/op	       0 allocs/op
BenchmarkFastCDCSize/1G-24          	       3	 436944458 ns/op	2457.39 MB/s	       899.0 chunks	 2796240 B/op	       0 allocs/op
```

After
```
goos: linux
goarch: amd64
pkg: github.com/jotfs/fastcdc-go
cpu: AMD Ryzen 9 7900X 12-Core Processor            
BenchmarkFastCDC-24        	1000000000	         0.4094 ns/op	2561553191774.19 MB/s
BenchmarkFastCDCSize/1k-24 	42984841	        28.75 ns/op	35619.80 MB/s	         1.000 chunks	       0 B/op	       0 allocs/op
BenchmarkFastCDCSize/4k-24 	16397151	        92.24 ns/op	44404.82 MB/s	         1.000 chunks	       0 B/op	       0 allocs/op
BenchmarkFastCDCSize/16k-24         	 6564519	       163.4 ns/op	100285.24 MB/s	         1.000 chunks	       1 B/op	       0 allocs/op
BenchmarkFastCDCSize/32k-24         	 2824311	       401.0 ns/op	81708.09 MB/s	         1.000 chunks	       2 B/op	       0 allocs/op
BenchmarkFastCDCSize/64k-24         	 1507483	       780.8 ns/op	83936.12 MB/s	         1.000 chunks	       5 B/op	       0 allocs/op
BenchmarkFastCDCSize/128k-24        	  759261	      1610 ns/op	81416.33 MB/s	         1.000 chunks	      11 B/op	       0 allocs/op
BenchmarkFastCDCSize/256k-24        	  370519	      3250 ns/op	80659.41 MB/s	         1.000 chunks	      22 B/op	       0 allocs/op
BenchmarkFastCDCSize/512k-24        	   11664	    104787 ns/op	5003.36 MB/s	         1.000 chunks	     719 B/op	       0 allocs/op
BenchmarkFastCDCSize/1M-24          	    3712	    333342 ns/op	3145.65 MB/s	         1.000 chunks	    2259 B/op	       0 allocs/op
BenchmarkFastCDCSize/4M-24          	     717	   1548126 ns/op	2709.28 MB/s	         4.000 chunks	   11699 B/op	       0 allocs/op
BenchmarkFastCDCSize/16M-24         	     198	   5896784 ns/op	2845.15 MB/s	        15.00 chunks	   42367 B/op	       0 allocs/op
BenchmarkFastCDCSize/32M-24         	     102	  12041355 ns/op	2786.60 MB/s	        29.00 chunks	   82242 B/op	       0 allocs/op
BenchmarkFastCDCSize/64M-24         	      42	  25091763 ns/op	2674.54 MB/s	        52.00 chunks	  199731 B/op	       0 allocs/op
BenchmarkFastCDCSize/128M-24        	      22	  48629186 ns/op	2760.02 MB/s	       112.0 chunks	  381305 B/op	       0 allocs/op
BenchmarkFastCDCSize/512M-24        	       6	 193774315 ns/op	2770.60 MB/s	       460.0 chunks	 1398120 B/op	       0 allocs/op
BenchmarkFastCDCSize/1G-24          	       3	 390436377 ns/op	2750.11 MB/s	       899.0 chunks	 2796240 B/op	       0 allocs/op

```
